### PR TITLE
do not change method name casing

### DIFF
--- a/Tmds.DBus.SourceGenerator/DBusSourceGenerator.Proxy.cs
+++ b/Tmds.DBus.SourceGenerator/DBusSourceGenerator.Proxy.cs
@@ -71,7 +71,7 @@ namespace Tmds.DBus.SourceGenerator
                                 Argument(IdentifierName(x.Name is not null ? SanitizeIdentifier(x.Name) : $"arg{i}")))))
                     .ToArray() ?? Array.Empty<ExpressionStatementSyntax>();
 
-                BlockSyntax createMessageBody = MakeCreateMessageBody(IdentifierName("Interface"), Pascalize(dBusMethod.Name!), ParseSignature(inArgs), statements);
+                BlockSyntax createMessageBody = MakeCreateMessageBody(IdentifierName("Interface"), dBusMethod.Name!, ParseSignature(inArgs), statements);
 
                 MethodDeclarationSyntax proxyMethod = MethodDeclaration(ParseTypeName(returnType), $"{Pascalize(dBusMethod.Name!)}Async")
                     .AddModifiers(Token(SyntaxKind.PublicKeyword));


### PR DESCRIPTION
[References](https://github.com/affederaffe/Tmds.DBus.SourceGenerator/issues/4) 

the method name as defined in the interface file.

Some interfaces may not respect pascal casing.
Forcing pascal case will try to call methods that do not exist