### PR TITLE
Bump Tmds.DBus.Protocol baseline to 0.94.0

### DIFF
--- a/DebugSourceGenerator/DebugSourceGenerator.csproj
+++ b/DebugSourceGenerator/DebugSourceGenerator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -39,7 +39,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Tmds.DBus.Protocol" Version="0.90.0" />
+        <PackageReference Include="Tmds.DBus.Protocol" Version="0.94.0" />
         <ProjectReference Include="../Tmds.DBus.SourceGenerator/Tmds.DBus.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 

--- a/Tmds.DBus.SourceGenerator/Tmds.DBus.SourceGenerator.csproj
+++ b/Tmds.DBus.SourceGenerator/Tmds.DBus.SourceGenerator.csproj
@@ -33,7 +33,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
-        <PackageReference Include="Tmds.DBus.Protocol" Version="0.90.0" PrivateAssets="all" GeneratePathProperty="true" />
+        <PackageReference Include="Tmds.DBus.Protocol" Version="0.94.0" PrivateAssets="all" GeneratePathProperty="true" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Closes #38

## Summary
- bump internal `Tmds.DBus.Protocol` package references from `0.90.0` to `0.94.0`
  - `Tmds.DBus.SourceGenerator/Tmds.DBus.SourceGenerator.csproj`
  - `DebugSourceGenerator/DebugSourceGenerator.csproj`

## Why
Consumer upgrades to `Tmds.DBus` / `Tmds.DBus.Protocol` `0.94.0` failed in generated code with missing symbols. This updates the generator baseline to match current stable protocol APIs.

## Validation
- `dotnet build Tmds.DBus.SourceGenerator.slnx -c Release`